### PR TITLE
feat: add scheduled animation every 5 min with day/night GIF and fade

### DIFF
--- a/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
+++ b/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
@@ -51,9 +51,11 @@ struct AppConfig {
   char wifi_password[64] = "changeme";       // [wifi] password
   char ntp_server[64]    = "pool.ntp.org";   // [clock] ntp_server
   int  gmt_offset_hours  = 1;                // [clock] gmt_offset  (e.g. 1 for UTC+1, -5 for UTC-5)
-  bool alarm_enabled     = false;            // [alarm] enabled
-  int  alarm_hour        = 7;                // [alarm] time HH
-  int  alarm_minute      = 0;                // [alarm] time MM
+  bool alarm_enabled          = false;       // [alarm] enabled
+  int  alarm_hour             = 7;           // [alarm] time HH
+  int  alarm_minute           = 0;           // [alarm] time MM
+  bool anim_schedule_enabled  = true;        // [animation] schedule
+  int  anim_duration_sec      = 10;          // [animation] duration
 } cfg;
 
 // ─── Pin definitions ─────────────────────────────────────────────────────────
@@ -140,8 +142,9 @@ bool      imuReady  = false;
 // ─── Brightness + tilt timer handles — valid only while Status screen is open ─
 lv_obj_t   *label_brightness = nullptr;
 lv_timer_t *tilt_timer       = nullptr;
-lv_timer_t *buzzer_timer     = nullptr;  // alarm beep pattern timer
-bool        buzzer_active    = false;
+lv_timer_t *buzzer_timer      = nullptr;  // alarm beep pattern timer
+bool        buzzer_active     = false;
+lv_timer_t *sched_close_timer = nullptr;  // auto-close timer for scheduled GIF
 
 
 
@@ -404,6 +407,21 @@ static void load_config()
         }
       }
     }
+
+    // ── [animation] ─────────────────────────────────────────────────────
+    else if (strcmp(section, "animation") == 0) {
+      if (strcmp(key, "schedule") == 0) {
+        cfg.anim_schedule_enabled = (strcmp(val, "true") == 0 || strcmp(val, "1") == 0);
+        Serial.printf("[CFG]   anim.schedule  = %s\n",
+                      cfg.anim_schedule_enabled ? "true" : "false");
+      }
+      else if (strcmp(key, "duration") == 0) {
+        cfg.anim_duration_sec = atoi(val);
+        if (cfg.anim_duration_sec < 3)  cfg.anim_duration_sec = 3;
+        if (cfg.anim_duration_sec > 60) cfg.anim_duration_sec = 60;
+        Serial.printf("[CFG]   anim.duration  = %ds\n", cfg.anim_duration_sec);
+      }
+    }
   }
 
   f.close();
@@ -595,12 +613,73 @@ static void wifi_poll_cb(lv_timer_t * /*t*/)
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
+//  SCHEDULED ANIMATION  —  every 5 min, configurable duration, 800 ms fade
+//  Day (07:00–19:59): smile GIF.  Night (20:00–06:59): sleep GIF.
+//  Only fires when the clock face is visible and no overlay is open.
+//  Touch the screen at any time to dismiss immediately.
+// ══════════════════════════════════════════════════════════════════════════════
+static bool is_night_time(int hour)
+{
+  return (hour >= 20 || hour < 7);
+}
+
+static void sched_gif_close_cb(lv_timer_t *t)
+{
+  lv_timer_del(t);
+  sched_close_timer = nullptr;
+  if (!overlay_cont) return;
+
+  lv_anim_t a;
+  lv_anim_init(&a);
+  lv_anim_set_var(&a, overlay_cont);
+  lv_anim_set_exec_cb(&a, [](void *obj, int32_t v) {
+    if (obj) lv_obj_set_style_opa((lv_obj_t *)obj, (lv_opa_t)v, 0);
+  });
+  lv_anim_set_values(&a, LV_OPA_COVER, LV_OPA_TRANSP);
+  lv_anim_set_duration(&a, 800);
+  lv_anim_set_ready_cb(&a, [](lv_anim_t * /*a*/) {
+    if (overlay_cont) {
+      if (tilt_timer) { lv_timer_del(tilt_timer); tilt_timer = nullptr; }
+      label_brightness = nullptr;
+      lv_obj_del(overlay_cont);
+      overlay_cont = nullptr;
+      Serial.println("[ANIM] Scheduled GIF closed (fade)");
+    }
+  });
+  lv_anim_start(&a);
+}
+
+static void run_scheduled_animation(int hour)
+{
+  if (!cfg.anim_schedule_enabled) return;
+  if (!sdCardAvailable)           return;
+  if (overlay_cont)               return;  // another screen already open
+  if (!home_time_lbl)             return;  // clock face not visible yet
+
+  const char *path = is_night_time(hour) ? GIF_SLEEP_PATH : GIF_SMILE_PATH;
+  Serial.printf("[ANIM] %s GIF for %ds\n",
+                is_night_time(hour) ? "sleep" : "smile", cfg.anim_duration_sec);
+
+  show_gif_fullscreen(path);
+
+  if (overlay_cont) {
+    sched_close_timer = lv_timer_create(sched_gif_close_cb,
+                                         (uint32_t)cfg.anim_duration_sec * 1000UL,
+                                         nullptr);
+    lv_timer_set_repeat_count(sched_close_timer, 1);
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
 //  DAILY AUTOMATION  —  brightness schedule + sleep GIF
 //  Called once per minute from clock_tick_cb (only when minute changes).
 // ══════════════════════════════════════════════════════════════════════════════
 static void run_daily_automation(int hour, int minute)
 {
   Serial.printf("[SCHED] %02d:%02d\n", hour, minute);
+
+  // ── Scheduled animation every 5 minutes ──────────────────────────────────
+  if (minute % 5 == 0) run_scheduled_animation(hour);
 
   // ── Evening dimming ───────────────────────────────────────────────────────
   if (hour == 19 && minute ==  0) set_brightness(25);
@@ -684,6 +763,8 @@ static void overlay_close_event_cb(lv_event_t *e)
       tilt_timer = nullptr;
     }
     label_brightness = nullptr;  // label is about to be destroyed
+    // Cancel scheduled GIF auto-close if user taps during animation
+    if (sched_close_timer) { lv_timer_del(sched_close_timer); sched_close_timer = nullptr; }
     // Stop buzzer if alarm was playing (screen touch = acknowledge alarm)
     buzzer_stop();
     lv_obj_del(overlay_cont);  // frees GIF decoder + canvas automatically

--- a/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
+++ b/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
@@ -868,7 +868,7 @@ static void show_gif_fullscreen(const char *path)
   // add_back_hint(overlay_cont);
 }
 
-// ── Tilt poll: runs every 200 ms ONLY while status screen is open ────────────
+// ── Tilt poll: runs every 400 ms ONLY while status screen is open ────────────
 static void tilt_poll_cb(lv_timer_t * /*t*/)
 {
   if (!imuReady || !overlay_cont) return;
@@ -971,8 +971,8 @@ static void show_status_screen(void)
   lv_obj_align(label_brightness, LV_ALIGN_LEFT_MID, 20, 28);
   lv_obj_add_flag(label_brightness, LV_OBJ_FLAG_IGNORE_LAYOUT);
 
-  // Start tilt poll timer — 200 ms, runs while this screen is open
-  tilt_timer = lv_timer_create(tilt_poll_cb, 200, nullptr);
+  // Start tilt poll timer — 400 ms, runs while this screen is open
+  tilt_timer = lv_timer_create(tilt_poll_cb, 400, nullptr);
 
   add_back_hint(overlay_cont);
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A smart animated clock for kids built on the **Waveshare ESP32-C6 Touch LCD 1.47
 | **Big clock face** | HH:MM in a full-screen custom font (Montserrat 96px) |
 | **Hello! splash** | Shown for 2.5 s on boot before the clock appears |
 | **Animated GIFs** | Smile (day) and Sleep (night) emotions from SD card |
-| **Scheduled animation** | GIF plays every 5 min for 10 s (configurable), fades back to clock _(coming in v1.1)_ |
+| **Scheduled animation** | GIF plays every 5 min (configurable duration), 800 ms fade back to clock |
 | **Night mode** | Sleep GIF used automatically between 20:00 and 07:00 |
 | **Alarm** | Configurable wake-up time, buzzer beeps, smile GIF, stops on touch |
 | **Brightness schedule** | Auto-dims at 19:00 → 19:30 → 20:00, brightens at 06:00 → 07:00 |
@@ -173,6 +173,13 @@ ntp_server = pool.ntp.org
 [alarm]
 enabled = true
 time = 07:10
+
+[animation]
+# Play smile GIF (day) or sleep GIF (night) automatically every 5 minutes
+# set schedule = false to disable
+schedule = true
+# Seconds the GIF plays before fading back to the clock (3-60)
+duration = 10
 ```
 
 | Section | Key | Type | Default | Description |
@@ -183,6 +190,8 @@ time = 07:10
 | `[clock]` | `ntp_server` | string | `pool.ntp.org` | NTP time server |
 | `[alarm]` | `enabled` | bool | `false` | Enable morning alarm |
 | `[alarm]` | `time` | `HH:MM` | `07:00` | Alarm time |
+| `[animation]` | `schedule` | bool | `true` | Enable periodic GIF every 5 min |
+| `[animation]` | `duration` | int (3–60) | `10` | Seconds each GIF plays before fading |
 
 > If `config.ini` is missing the firmware boots with the hardcoded defaults shown above.
 
@@ -257,6 +266,21 @@ All times are local time. Timezone is set via `gmt_offset` in `[clock]` in `conf
 | 21:00 | Sleep GIF closes automatically (if not already dismissed) |
 
 **Buzzer:** plays a `beep-beep-beep … pause` pattern (3 × 200 ms on, 700 ms pause) until the screen is touched.
+
+---
+
+## Scheduled Animation
+
+When `[animation] schedule = true`, a GIF plays automatically every 5 minutes for the configured duration, then fades back to the clock over 800 ms.
+
+| Time of day | GIF played |
+|---|---|
+| Day (07:00–19:59) | `cruzr_smile.gif` |
+| Night (20:00–06:59) | `cruzr_sleep.gif` |
+
+- Skipped silently if any sub-screen is already open
+- Touch the screen at any time to dismiss immediately
+- The GIF fades out over 800 ms when the timer expires
 
 ---
 
@@ -349,7 +373,7 @@ All times are local time. Timezone is set via `gmt_offset` in `[clock]` in `conf
 - **SD ↔ LVGL filesystem bridge** — a custom `lv_fs_drv_t` registered under drive letter `'S'` forwards all LVGL file operations to the Arduino `SD` library. This lets `lv_gif_set_src()` open files directly from the card.
 - **GIF memory management** — the LVGL GIF decoder needs a contiguous block for its canvas. GIFs are pre-scaled to 160×86 px (55 KB canvas) so they fit alongside the WiFi stack. The render buffer uses 20 scan lines for good throughput without exhausting RAM.
 - **config.ini** — parsed once at boot with a hand-rolled INI reader (no external library). Comments (`#`), blank lines and whitespace around `=` are all handled. The `[alarm]` section is rewritten on save while preserving all other sections and comments.
-- **Scheduled animation** — periodic GIF playback (smile by day, sleep by night) with an 800 ms fade back to the clock. Implemented as a separate feature branch, available in v1.1.
+- **Scheduled animation** — `run_scheduled_animation()` fires on `minute % 5 == 0` inside `run_daily_automation()`. A one-shot LVGL timer triggers `sched_gif_close_cb()` after the configured duration, which fades opacity 100→0% over 800 ms via `lv_anim` then deletes the overlay. Touching the screen cancels the timer before it fires.
 
 ---
 
@@ -358,7 +382,7 @@ All times are local time. Timezone is set via `gmt_offset` in `[clock]` in `conf
 | Version | Status | Feature |
 |---|---|---|
 | v1.0 | ✅ released | Clock, alarms, GIF on tap, buzzer, brightness tilt, config.ini |
-| v1.1 | 🔄 in progress | Scheduled animation (smile/sleep every 5 min with fade) |
+| v1.1 | ✅ released | Scheduled animation (smile/sleep every 5 min, 800 ms fade) |
 
 ## Contributing
 

--- a/sd_card_root/config.ini
+++ b/sd_card_root/config.ini
@@ -13,3 +13,10 @@ ntp_server = pool.ntp.org
 [alarm]
 enabled = true
 time = 07:10
+
+[animation]
+# Play smile GIF (day) or sleep GIF (night) automatically every 5 minutes
+# set schedule = false to disable
+schedule = true
+# Seconds the GIF plays before fading back to the clock (3-60)
+duration = 10


### PR DESCRIPTION
- New [animation] section in config.ini: schedule (bool) + duration (3-60s)
- is_night_time(): smile GIF 07:00-19:59, sleep GIF 20:00-06:59
- run_scheduled_animation(): fires on minute % 5 == 0 from run_daily_automation
- sched_gif_close_cb(): lv_anim fade 800ms then deletes overlay
- sched_close_timer cancelled on touch so no double-fire
- README: [animation] config reference, Scheduled Animation section, Roadmap v1.1
- used https://ezgif.com/speed/ to increase the speed of the animations