### PR TITLE
replacing uppet-right sleepy GIF with Analog Clock

### DIFF
--- a/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
+++ b/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
@@ -169,6 +169,7 @@ const char *emotion_current_gif = nullptr; // tracks which GIF is showing
 lv_timer_t *buzzer_timer      = nullptr;  // alarm beep pattern timer
 bool        buzzer_active     = false;
 lv_timer_t *sched_close_timer = nullptr;  // auto-close timer for scheduled GIF
+lv_timer_t *aclock_timer      = nullptr;  // 1-min refresh for analog clock overlay
 
 // ─── Carousel / modal settings ────────────────────────────────────────────────
 lv_obj_t   *modal_cont   = nullptr;  // carousel / editor full-screen modal
@@ -1251,7 +1252,7 @@ static void run_daily_automation(int hour, int minute)
       alarm_ntp_pending = false;
       Serial.println("[ALARM] NTP timeout — showing warning alarm");
       close_scheduled_gif();
-      set_brightness(50);
+      set_brightness(80);
       // Warning overlay: no GIF, just text
       if (!overlay_cont) {
         overlay_cont = make_overlay(lv_color_make(20, 20, 20));
@@ -1359,6 +1360,8 @@ static void overlay_close_event_cb(lv_event_t *e)
     label_brightness = nullptr;  // label is about to be destroyed
     // Cancel scheduled GIF auto-close if user taps during animation
     if (sched_close_timer) { lv_timer_del(sched_close_timer); sched_close_timer = nullptr; }
+    // Cancel analog clock refresh timer
+    if (aclock_timer) { lv_timer_del(aclock_timer); aclock_timer = nullptr; }
     // Stop buzzer if alarm was playing (screen touch = acknowledge alarm)
     buzzer_stop();
     lv_obj_del(overlay_cont);  // frees GIF decoder + canvas automatically
@@ -2199,14 +2202,13 @@ static void carousel_build()
   lv_label_set_text(hint,"tap in or hold to exit");
   lv_obj_set_style_text_color(hint,lv_color_make(80,80,100),0);
   lv_obj_set_style_text_opa(hint,LV_OPA_60,0);
-  lv_obj_set_style_text_font(hint,&dejavu_mono_14,0);
+  lv_obj_set_style_text_font(hint,&lv_font_montserrat_14,0);
   lv_obj_align(hint,LV_ALIGN_BOTTOM_MID,0,-18);  // above the dots
 
   // Position dots — bottom row
   for (int i=0;i<4;i++) {
     lv_obj_t*dot=lv_label_create(modal_cont);
-    lv_obj_set_style_text_font(dot, &dejavu_mono_14, 0);
-    lv_label_set_text(dot, i==carousel_idx ? "\xe2\x97\x8f" : "\xe2\x97\x8b"); // "●" : "○"
+    lv_label_set_text(dot,i==carousel_idx?"●":"○");
     lv_obj_set_style_text_color(dot,
       i==carousel_idx?lv_color_white():lv_color_make(80,80,100),0);
     lv_obj_set_pos(dot,137+i*14,156);
@@ -3051,8 +3053,7 @@ static void apps_carousel_build()
   // 4 position dots
   for (int i = 0; i < 4; i++) {
     lv_obj_t *dot = lv_label_create(apps_cont);
-    lv_obj_set_style_text_font(dot, &dejavu_mono_14, 0);
-    lv_label_set_text(dot, i==apps_idx ? "\xe2\x97\x8f" : "\xe2\x97\x8b"); // "●" : "○"
+    lv_label_set_text(dot, i==apps_idx ? "\xe2\x97\x8f" : "\xe2\x97\x8b");
     lv_obj_set_style_text_color(dot, i==apps_idx ? lv_color_white() : lv_color_make(80,80,100), 0);
     lv_obj_set_pos(dot, 137 + i * 14, 156);
   }
@@ -3097,8 +3098,194 @@ static void zone_ul_cb(lv_event_t *e)
   }
 }
 
+// ══════════════════════════════════════════════════════════════════════════════
+//  ANALOG CLOCK  (upper-right zone)
+//
+//  Drawn via LVGL v9 LV_EVENT_DRAW_MAIN callbacks — zero extra RAM, no canvas.
+//  Layout: screen 320×172, clock centred at (160, 86), radius R=76 px.
+//
+//  Visual layers (back to front):
+//    1. Pie sector  — triangle fan, one 6° slice per elapsed minute, blue gradient
+//    2. Sector edge — thin arc from 12 o'clock to current minute
+//    3. Clock ring  — white circle outline
+//    4. 60 minute ticks (minor every 6°, medium every 30° between numbers)
+//    5. 12 hour numbers drawn at R-22
+//    6. Hour hand   — thick, 55% R
+//    7. Minute hand — thin,  80% R
+//    8. Centre dot  — filled blue circle
+// ══════════════════════════════════════════════════════════════════════════════
+
+// Clockwise-from-12 degrees → screen (x, y)
+static void ac_pt(int cx, int cy, int r, float adeg,
+                  lv_value_precise_t *ox, lv_value_precise_t *oy)
+{
+  float rad = adeg * 0.017453293f;
+  *ox = (lv_value_precise_t)(cx + r * sinf(rad) + 0.5f);
+  *oy = (lv_value_precise_t)(cy - r * cosf(rad) + 0.5f);
+}
+
+static void aclock_draw_cb(lv_event_t *e)
+{
+  lv_layer_t *layer = lv_event_get_layer(e);
+  const int cx = 160, cy = 86, R = 76;
+
+  time_t now_t = time(nullptr);
+  struct tm tm; localtime_r(&now_t, &tm);
+  int hr  = tm.tm_hour % 12;
+  int mn  = tm.tm_min;
+  int sec = tm.tm_sec;
+
+  float min_angle = mn * 6.0f;                       // 0–354°
+  float hr_angle  = hr * 30.0f + mn * 0.5f;          // fractional hour
+  float sec_angle = sec * 6.0f;                       // thin seconds arc
+
+  // ── 1. Pie sector — gradient: early slices dim, late slices bright ────────
+  if (mn > 0) {
+    lv_draw_triangle_dsc_t tri;
+    lv_draw_triangle_dsc_init(&tri);
+    tri.p[0].x = (lv_value_precise_t)cx;
+    tri.p[0].y = (lv_value_precise_t)cy;
+    for (int i = 0; i < mn; i++) {
+      // Gradient: opacity ramps from 30 → 160 across the sweep
+      lv_opa_t opa = (lv_opa_t)(30 + (i * 130) / (mn > 1 ? mn - 1 : 1));
+      tri.color = lv_color_make(40, 100, 220);
+      tri.opa   = opa;
+      ac_pt(cx, cy, R - 6, i * 6.0f,       &tri.p[1].x, &tri.p[1].y);
+      ac_pt(cx, cy, R - 6, (i + 1) * 6.0f, &tri.p[2].x, &tri.p[2].y);
+      lv_draw_triangle(layer, &tri);
+    }
+
+    // ── 2. Sector edge — subtle arc from 12 to current minute ────────────
+    lv_draw_arc_dsc_t edge;
+    lv_draw_arc_dsc_init(&edge);
+    edge.center.x   = (lv_value_precise_t)cx;
+    edge.center.y   = (lv_value_precise_t)cy;
+    edge.radius      = R - 6;
+    edge.start_angle = 270;                            // LVGL 0° = 3 o'clock
+    edge.end_angle   = (uint16_t)(270 + mn * 6) % 360;
+    edge.width       = 2;
+    edge.color       = lv_color_make(100, 180, 255);
+    edge.opa         = LV_OPA_80;
+    if (mn > 0) lv_draw_arc(layer, &edge);
+
+    // ── Thin seconds arc — from 12 to current second (faint) ─────────────
+    lv_draw_arc_dsc_t sarc;
+    lv_draw_arc_dsc_init(&sarc);
+    sarc.center.x   = (lv_value_precise_t)cx;
+    sarc.center.y   = (lv_value_precise_t)cy;
+    sarc.radius      = R - 3;
+    sarc.start_angle = 270;
+    sarc.end_angle   = (uint16_t)(270 + (int)sec_angle) % 360;
+    sarc.width       = 1;
+    sarc.color       = lv_color_make(150, 210, 255);
+    sarc.opa         = LV_OPA_40;
+    if (sec > 0) lv_draw_arc(layer, &sarc);
+  }
+
+  // ── 3. Clock ring ─────────────────────────────────────────────────────────
+  lv_draw_arc_dsc_t ring;
+  lv_draw_arc_dsc_init(&ring);
+  ring.center.x   = (lv_value_precise_t)cx;
+  ring.center.y   = (lv_value_precise_t)cy;
+  ring.radius      = R;
+  ring.start_angle = 0;
+  ring.end_angle   = 360;
+  ring.width       = 2;
+  ring.color       = lv_color_make(100, 160, 255);
+  ring.opa         = LV_OPA_COVER;
+  lv_draw_arc(layer, &ring);
+
+  // ── 4. 60 minute ticks ────────────────────────────────────────────────────
+  lv_draw_line_dsc_t tick;
+  lv_draw_line_dsc_init(&tick);
+  tick.opa = LV_OPA_COVER;
+  for (int i = 0; i < 60; i++) {
+    float a    = i * 6.0f;
+    bool  is5  = (i % 5 == 0);   // on an hour mark
+    tick.width = is5 ? 2 : 1;
+    int   inner = is5 ? R - 14 : R - 7;
+    tick.color  = is5 ? lv_color_make(180, 210, 255)
+                      : lv_color_make(80, 120, 180);
+    ac_pt(cx, cy, R - 2, a, &tick.p1.x, &tick.p1.y);
+    ac_pt(cx, cy, inner, a, &tick.p2.x, &tick.p2.y);
+    lv_draw_line(layer, &tick);
+  }
+
+  // ── 5. Hour numbers ───────────────────────────────────────────────────────
+  static const char *hn[12] = {
+    "12","1","2","3","4","5","6","7","8","9","10","11"
+  };
+  const int R_NUM = R - 24;
+  lv_draw_label_dsc_t ldsc;
+  lv_draw_label_dsc_init(&ldsc);
+  ldsc.font  = &lv_font_montserrat_14;
+  ldsc.color = lv_color_make(200, 230, 255);
+  ldsc.opa   = LV_OPA_COVER;
+  ldsc.align = LV_TEXT_ALIGN_CENTER;
+  for (int i = 0; i < 12; i++) {
+    float a  = i * 30.0f;
+    int   nx = (int)(cx + R_NUM * sinf(a * 0.017453293f) + 0.5f);
+    int   ny = (int)(cy - R_NUM * cosf(a * 0.017453293f) + 0.5f);
+    lv_area_t la = {
+      (lv_coord_t)(nx - 14), (lv_coord_t)(ny - 9),
+      (lv_coord_t)(nx + 14), (lv_coord_t)(ny + 9)
+    };
+    // LVGL v9: text is set in dsc.text, lv_draw_label takes 3 args
+    ldsc.text = hn[i];
+    lv_draw_label(layer, &ldsc, &la);
+  }
+
+  // ── 6. Hour hand (thick, 55% R) ───────────────────────────────────────────
+  lv_draw_line_dsc_t hh;
+  lv_draw_line_dsc_init(&hh);
+  hh.width = 5; hh.color = lv_color_white(); hh.opa = LV_OPA_COVER;
+  hh.round_start = 1; hh.round_end = 1;
+  hh.p1.x = (lv_value_precise_t)cx;
+  hh.p1.y = (lv_value_precise_t)cy;
+  ac_pt(cx, cy, (int)(R * 0.55f), hr_angle, &hh.p2.x, &hh.p2.y);
+  lv_draw_line(layer, &hh);
+
+  // ── 7. Minute hand (thin, 80% R) ──────────────────────────────────────────
+  lv_draw_line_dsc_t mh;
+  lv_draw_line_dsc_init(&mh);
+  mh.width = 2; mh.color = lv_color_white(); mh.opa = LV_OPA_COVER;
+  mh.round_start = 1; mh.round_end = 1;
+  mh.p1.x = (lv_value_precise_t)cx;
+  mh.p1.y = (lv_value_precise_t)cy;
+  ac_pt(cx, cy, (int)(R * 0.80f), min_angle, &mh.p2.x, &mh.p2.y);
+  lv_draw_line(layer, &mh);
+
+  // ── 8. Centre dot (filled blue circle) ───────────────────────────────────
+  lv_draw_arc_dsc_t dot;
+  lv_draw_arc_dsc_init(&dot);
+  dot.center.x   = (lv_value_precise_t)cx;
+  dot.center.y   = (lv_value_precise_t)cy;
+  dot.radius      = 5;
+  dot.start_angle = 0;
+  dot.end_angle   = 360;
+  dot.width       = 5;
+  dot.color       = lv_color_make(60, 140, 255);
+  dot.opa         = LV_OPA_COVER;
+  lv_draw_arc(layer, &dot);
+}
+
+static void aclock_refresh_cb(lv_timer_t * /*t*/)
+{
+  if (overlay_cont) lv_obj_invalidate(overlay_cont);
+}
+
+static void show_analog_clock()
+{
+  if (overlay_cont) return;
+  overlay_cont = make_overlay(lv_color_make(4, 8, 24));  // deep navy
+  lv_obj_add_event_cb(overlay_cont, aclock_draw_cb, LV_EVENT_DRAW_MAIN, nullptr);
+  // Refresh every 60 s so clock stays accurate; also invalidates on open
+  aclock_timer = lv_timer_create(aclock_refresh_cb, 60000, nullptr);
+  Serial.println("[CLOCK] Analog clock opened");
+}
+
 static void zone_ur_cb(lv_event_t *e)
-{ if (lv_event_get_code(e) == LV_EVENT_CLICKED) show_gif_fullscreen(GIF_SLEEP_PATH); }
+{ if (lv_event_get_code(e) == LV_EVENT_CLICKED) show_analog_clock(); }
 
 static void zone_ll_cb(lv_event_t *e)
 { if (lv_event_get_code(e) == LV_EVENT_CLICKED) show_status_screen(); }
@@ -3134,7 +3321,7 @@ static void home_screen_init(void)
   // Landscape 320×172. Each quadrant = 160×86 px.
   const struct { int16_t x; int16_t y; lv_event_cb_t cb; } zones[4] = {
     {   0,   0, zone_ul_cb },   // upper-left  → smile GIF
-    { 160,   0, zone_ur_cb },   // upper-right → sleep GIF
+    { 160,   0, zone_ur_cb },   // upper-right → analog clock
     {   0,  86, zone_ll_cb },   // lower-left  → WiFi/NTP/date status
     { 160,  86, zone_lr_cb },   // lower-right → battery
   };

--- a/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
+++ b/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
@@ -3054,7 +3054,8 @@ static void apps_carousel_build()
   // 4 position dots
   for (int i = 0; i < 4; i++) {
     lv_obj_t *dot = lv_label_create(apps_cont);
-    lv_label_set_text(dot, i==apps_idx ? "\xe2\x97\x8f" : "\xe2\x97\x8b");
+    lv_obj_set_style_text_font(dot, &dejavu_mono_14, 0);
+    lv_label_set_text(dot, i==apps_idx ? "\xe2\x97\x8f" : "\xe2\x97\x8b"); // "●" : "○"
     lv_obj_set_style_text_color(dot, i==apps_idx ? lv_color_white() : lv_color_make(80,80,100), 0);
     lv_obj_set_pos(dot, 137 + i * 14, 156);
   }

--- a/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
+++ b/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
@@ -3537,6 +3537,40 @@ void setup()
   apply_wifi_state();
   Serial.println("     Done.");
 
+  // ── Step 8: Low-battery gate ─────────────────────────────────────────────
+  // Read battery BEFORE building any UI. If critically low, show only the
+  // empty-battery icon (no text, no countdown) for 5 s then deep-sleep.
+  // Mirrors iPhone behaviour: clean, silent, no user interaction required.
+  {
+    uint16_t mv  = analogReadMilliVolts(BAT_PIN);
+    float    v   = mv * 3.0f / 1000.0f;
+    int      pct = battery_voltage_to_percent(v);
+    Serial.printf("[BAT] Boot check: %.2fV = %d%%\n", v, pct);
+
+    if (pct <= 10) {
+      Serial.println("[BAT] Low battery — showing icon then sleeping.");
+      lv_obj_t *scr = lv_scr_act();
+      lv_obj_set_style_bg_color(scr, lv_color_black(), 0);
+      lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
+
+      lv_obj_t *ico = lv_label_create(scr);
+      lv_label_set_text(ico, LV_SYMBOL_BATTERY_EMPTY);
+      lv_obj_set_style_text_font(ico, &lv_font_montserrat_48, 0);
+      lv_obj_set_style_text_color(ico, lv_color_white(), 0);
+      lv_obj_align(ico, LV_ALIGN_CENTER, 0, 0);
+
+      // Pump LVGL for 5 s so the icon actually renders — then sleep forever.
+      uint32_t t0 = millis();
+      while (millis() - t0 < 5000) { lv_timer_handler(); delay(5); }
+
+      ledcWrite(GFX_BL, 0);   // blank backlight
+      delay(100);
+      // No wakeup source — device sleeps until RESET is pressed
+      esp_deep_sleep_start();
+      return;  // never reached
+    }
+  }
+
   Serial.println("[8] Building UI...");
   home_screen_init();
 

--- a/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
+++ b/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.ino
@@ -1252,7 +1252,7 @@ static void run_daily_automation(int hour, int minute)
       alarm_ntp_pending = false;
       Serial.println("[ALARM] NTP timeout — showing warning alarm");
       close_scheduled_gif();
-      set_brightness(80);
+      set_brightness(50);
       // Warning overlay: no GIF, just text
       if (!overlay_cont) {
         overlay_cont = make_overlay(lv_color_make(20, 20, 20));
@@ -2202,13 +2202,14 @@ static void carousel_build()
   lv_label_set_text(hint,"tap in or hold to exit");
   lv_obj_set_style_text_color(hint,lv_color_make(80,80,100),0);
   lv_obj_set_style_text_opa(hint,LV_OPA_60,0);
-  lv_obj_set_style_text_font(hint,&lv_font_montserrat_14,0);
+  lv_obj_set_style_text_font(hint,&dejavu_mono_14,0);
   lv_obj_align(hint,LV_ALIGN_BOTTOM_MID,0,-18);  // above the dots
 
   // Position dots — bottom row
   for (int i=0;i<4;i++) {
     lv_obj_t*dot=lv_label_create(modal_cont);
-    lv_label_set_text(dot,i==carousel_idx?"●":"○");
+    lv_obj_set_style_text_font(dot, &dejavu_mono_14, 0);
+    lv_label_set_text(dot, i==carousel_idx ? "\xe2\x97\x8f" : "\xe2\x97\x8b"); // "●" : "○"
     lv_obj_set_style_text_color(dot,
       i==carousel_idx?lv_color_white():lv_color_make(80,80,100),0);
     lv_obj_set_pos(dot,137+i*14,156);

--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ Tap the centre to toggle WiFi on or off. No sub-screen. The description updates 
 
 ## Sub-screens
 
+### Analog Clock (upper-right tap)
+Top-right corner shows an Analog clock, view stays opened and refreshes every minute to display the correct time. Clicking on it will return  to the regular Time view. A filled sector centered on the clock center that starts at the top of the hour (12 o’clock) and sweeps clockwise to the current minute position, visually like a pie chart showing elapsed minutes in the current hour. 
+
 ### Status (lower-left tap)
 Title shows today's date (e.g. `Mon 23 Mar 2026`) when the RTC holds a valid time, falling back to `Status` on a fresh unconfigured boot. Shows WiFi connection status (SSID or disconnected), NTP sync state, and current brightness level. **Tilt the device left or right** while this screen is open to decrease or increase brightness in 10% steps.
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ The home screen has **four invisible touch zones**. Tap to open a sub-screen. **
 ```
 ┌─────────────────────────────────────────┐
 │                   │                     │
-│   Smile GIF       │    Sleep GIF        │
+│   Smile GIF       │    Analog Clock     │
 │   (upper-left)    │    (upper-right)    │
 │                   │                     │
 ├───────────────────┼─────────────────────┤
@@ -383,8 +383,6 @@ Tapping the **upper-left** zone opens the smile GIF as usual. While this GIF is 
 The swap happens in-place — the GIF changes without closing the overlay or any visible flicker. The tilt is polled every 400 ms. A threshold of 0.4 g on the X axis (forward/backward) and Y axis (left/right) must be exceeded for the emotion to change, so small accidental movements are ignored.
 
 Tapping the screen dismisses the animation and returns to the clock, as usual.
-
-> The upper-right zone always opens `cruzr_sleep.gif` directly with no tilt interaction — tilt emotion mode is exclusive to the upper-left zone.
 
 **Long-press the smile GIF** to enter the Apps Menu (math gate first).
 

--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ read: 8161
 | v1.4.0 | ✅ released | Emotion tilt GIF mode on upper-left tap (smile/sleep/sad/joy via IMU) |
 | v1.4.1 | ✅ released | Bugfix: Fix RTC drift after long deep sleep in the event of an alarm set, allow time for NTP sync |
 | v1.5.0 | ✅ released | Apps menu: math gate, Rock Paper Scissors, Rolling Dice, Flip a Coin, game sounds, DST-aware timezone |
-| v2.0.0 | workinprogress| Analog clock view & low-power startup gate |
+| v2.0.0 | ✅ released | Analog clock view & low-power startup gate |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ Long-press the battery screen to open the shutdown popup. After the countdown (o
 
 ### Waking up
 Press the **RESET** button on the device body. This always causes a clean reboot through the full boot sequence.
+Low-battery gate code will check at startup if the battery is > 10%.
 
 > The BOOT button on this board is wired to GPIO9, which is not a low-power GPIO on the ESP32-C6 and cannot trigger a wake-from-deep-sleep interrupt. RESET is the reliable wake method.
 
@@ -580,24 +581,43 @@ Skipped silently if any screen, overlay, or carousel is already open. Alarm and 
 ========== BOOT ==========
 [BOOT] Wake cause: cold boot / RESET button
 [1] Pulling CS pins HIGH...
+    Done.
 [2] SPI.begin(SCK=1, MISO=3, MOSI=2, CS=4)...
+    Done.
 [3] Initialising display...
     gfx->begin() OK.
+[BL] Backlight init at 50% (PWM=127)
+    Display ready.
 [4] Initialising touch...
+read: 8161
+    Touch ready.
 [4b] Initialising IMU...
     IMU ready.
 [5] Mounting SD card...
+    CS=4  SCK=1  MISO=3  MOSI=2  speed=4MHz
+    SD.begin() returned: true
     SD mounted OK — type: SD  size: 244 MB
 [CFG] Loading /config.ini...
 [CFG]   wifi.enabled       = true
-[CFG]   wifi.ssid          = myhomewifi
-[CFG]   wifi.password      = (hidden)
-[CFG]   clock.tz           = CET-1CEST,M3.5.0,M10.5.0/3
-[RTC] Restored time from log: 2026-03-30 09:15:00
-[TZ] Applied: CET-1CEST,M3.5.0,M10.5.0/3
+[CFG]   wifi.ssid     = myhomewifi
+[CFG]   wifi.password = (hidden)
+[CFG]   alarm.enabled      = true
+[CFG]   alarm.time         = 07:10
+[CFG]   alarm.beep_sequences = 5
+[CFG]   timer.duration      = 00:02
+[CFG]   timer.beep_sequences = 3
+[CFG]   menu.sounds    = true
+[CFG] Done. (49 lines read)
+[RTC] Restored UTC time from log: 2026-04-07 12:00:00
+    Checking for GIF at: /cruzr_emotions/cruzr_smile.gif
+    GIF found — 540954 bytes
 [6] Initialising LVGL...
 [7] Registering LVGL SD filesystem driver...
 [7b] Applying WiFi state from config...
+[TZ] Applied: CET-1CEST,M3.5.0,M10.5.0/3
+[WiFi] Enabling...
+     Done.
+[BAT] Boot check: 4.11V = 91%
 [8] Building UI...
 ========== SETUP DONE ==========
 ```
@@ -665,6 +685,7 @@ Skipped silently if any screen, overlay, or carousel is already open. Alarm and 
 | v1.4.0 | ✅ released | Emotion tilt GIF mode on upper-left tap (smile/sleep/sad/joy via IMU) |
 | v1.4.1 | ✅ released | Bugfix: Fix RTC drift after long deep sleep in the event of an alarm set, allow time for NTP sync |
 | v1.5.0 | ✅ released | Apps menu: math gate, Rock Paper Scissors, Rolling Dice, Flip a Coin, game sounds, DST-aware timezone |
+| v2.0.0 | workinprogress| Analog clock view & low-power startup gate |
 
 ## License
 


### PR DESCRIPTION
Here's exactly what was added and how it works:

**`aclock_timer`** global — added alongside `sched_close_timer`. Cleaned up in `overlay_close_event_cb` so it's cancelled when the user taps to return.

**`ac_pt(cx, cy, r, angle_deg, *ox, *oy)`** — converts clockwise-from-12 degrees to screen coordinates. 0°=top, 90°=right, 180°=bottom, 270°=left.

**`aclock_draw_cb`** fires on `LV_EVENT_DRAW_MAIN` every time LVGL repaints the overlay. Drawing order (back to front):

1. **Pie sector** — triangle fan, one 6° triangle per elapsed minute. Opacity ramps from 30 (just after 12) to 160 (current minute), creating a gradient that intensifies toward the hand — similar to the esphome example you linked
2. **Sector edge arc** — thin bright blue arc from 12 to the current minute position, outlining the swept area
3. **Seconds arc** — very faint thin arc from 12 to current second at R-3 (finer resolution, `LV_OPA_40`)
4. **Clock ring** — blue circle outline at R=76
5. **60 tick marks** — minor (1px, 5px long) every 6°; medium (2px, 12px long) every 30° (at hour positions). Hour-position ticks are lighter blue to complement the numbers
6. **12 hour numbers** — drawn with `lv_draw_label()` at R-24 using montserrat_14, light blue
7. **Hour hand** — 5px thick, 55% R, white, rounded ends
8. **Minute hand** — 2px thin, 80% R, white, rounded ends (drawn last, on top of sector)
9. **Centre dot** — filled blue circle r=5

**Refresh** — `aclock_refresh_cb` calls `lv_obj_invalidate(overlay_cont)` every 60 seconds → triggers `aclock_draw_cb` with fresh time. The overlay also invalidates immediately on open since LVGL repaints after creation.

**Tap to close** — `make_overlay()` already registers `overlay_close_event_cb` on `LV_EVENT_CLICKED`, so tapping returns to the clock face exactly like the GIFs do.

---

The low-battery gate is inserted between the WiFi/NTP init (step 7b) and `home_screen_init` (step 8), which is the correct moment — LVGL's display driver is fully registered so it can render, but no UI objects have been created yet.

What happens at ≤ 10%:
1. Black screen background set
2. `LV_SYMBOL_BATTERY_EMPTY` label created in `lv_font_montserrat_48`, white, centred — nothing else
3. `lv_timer_handler()` pumped in a tight 5-second loop so LVGL actually flushes the icon to the display
4. Backlight blanked, then `esp_deep_sleep_start()` with **no wakeup source configured** — the device sleeps until RESET is pressed, exactly like an iPhone refusing to boot on low battery
5. `return` after deep sleep is unreachable but stops the compiler warning

The existing `shutdown_execute()` path (triggered by long-pressing the battery screen) is unchanged — it still sets a timer wakeup for the alarm. This new path intentionally skips that because there's no point scheduling an alarm wake if the battery is already critical.