### PR TITLE
Document how to flash the device, in the release notes, the README and the site

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: read   # to pull the merged PR's title and body into the notes
+  contents: write   # also covers --generate-notes; that endpoint needs no more
 
 env:
   ESP32_CORE_VERSION: "3.3.11"
@@ -73,40 +72,6 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "sketch=$SKETCH" >> "$GITHUB_OUTPUT"
-
-      # The PR whose merge produced this push to main. Its title and body head
-      # the release notes, so the release says what actually changed rather than
-      # only how it was built. Runs before the build and before the tag so that
-      # a token or permission problem surfaces while nothing irreversible has
-      # happened yet. Writes a ready-made markdown fragment rather than step
-      # outputs, which keeps arbitrary PR text out of shell interpolation.
-      # Empty when the push had no associated PR — the notes then simply start
-      # at the flashing section.
-      - name: Summarise merged pull request
-        if: steps.version.outputs.should-release == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -uo pipefail
-          : > pr-section.md
-
-          if ! gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" > pr.json 2>/dev/null; then
-            echo "::notice::Could not query pull requests for ${GITHUB_SHA}; notes will omit the summary."
-            exit 0
-          fi
-
-          NUM="$(jq -r '.[0].number // empty' pr.json)"
-          if [ -z "$NUM" ]; then
-            echo "::notice::No pull request associated with ${GITHUB_SHA}; notes will omit the summary."
-            exit 0
-          fi
-
-          {
-            printf '## %s\n\n' "$(jq -r '.[0].title // ""' pr.json)"
-            jq -r '.[0].body // ""' pr.json
-            printf '\n_Merged in #%s._\n\n---\n\n' "$NUM"
-          } > pr-section.md
-          echo "::notice::Release notes will include PR #${NUM}."
 
       - name: Build firmware
         if: steps.version.outputs.should-release == 'true'
@@ -176,8 +141,6 @@ jobs:
           set -euo pipefail
 
           {
-            cat pr-section.md          # empty when the push had no PR
-
             echo "## Flashing"
             echo ""
             echo "\`firmware-${VERSION}-full.bin\` is a complete image — bootloader, partition"
@@ -229,7 +192,12 @@ jobs:
             echo "\`\`\`"
           } > notes.md
 
-          FLAGS=(--title "$VERSION" --notes-file notes.md)
+          # --generate-notes has GitHub append its own "What's Changed" section:
+          # every PR merged since the previous tag, plus contributors and a
+          # compare link. That covers a release spanning several PRs, which
+          # reading the merge commit's own PR would not. notes.md is the body,
+          # so the generated changelog lands after it.
+          FLAGS=(--title "$VERSION" --notes-file notes.md --generate-notes)
           [ "$PRERELEASE" = "true" ] && FLAGS+=(--prerelease)
 
           gh release create "$VERSION" "${FLAGS[@]}" release/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: read   # to pull the merged PR's title and body into the notes
 
 env:
   ESP32_CORE_VERSION: "3.3.11"
@@ -72,6 +73,40 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "sketch=$SKETCH" >> "$GITHUB_OUTPUT"
+
+      # The PR whose merge produced this push to main. Its title and body head
+      # the release notes, so the release says what actually changed rather than
+      # only how it was built. Runs before the build and before the tag so that
+      # a token or permission problem surfaces while nothing irreversible has
+      # happened yet. Writes a ready-made markdown fragment rather than step
+      # outputs, which keeps arbitrary PR text out of shell interpolation.
+      # Empty when the push had no associated PR — the notes then simply start
+      # at the flashing section.
+      - name: Summarise merged pull request
+        if: steps.version.outputs.should-release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          : > pr-section.md
+
+          if ! gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" > pr.json 2>/dev/null; then
+            echo "::notice::Could not query pull requests for ${GITHUB_SHA}; notes will omit the summary."
+            exit 0
+          fi
+
+          NUM="$(jq -r '.[0].number // empty' pr.json)"
+          if [ -z "$NUM" ]; then
+            echo "::notice::No pull request associated with ${GITHUB_SHA}; notes will omit the summary."
+            exit 0
+          fi
+
+          {
+            printf '## %s\n\n' "$(jq -r '.[0].title // ""' pr.json)"
+            jq -r '.[0].body // ""' pr.json
+            printf '\n_Merged in #%s._\n\n---\n\n' "$NUM"
+          } > pr-section.md
+          echo "::notice::Release notes will include PR #${NUM}."
 
       - name: Build firmware
         if: steps.version.outputs.should-release == 'true'
@@ -141,6 +176,48 @@ jobs:
           set -euo pipefail
 
           {
+            cat pr-section.md          # empty when the push had no PR
+
+            echo "## Flashing"
+            echo ""
+            echo "\`firmware-${VERSION}-full.bin\` is a complete image — bootloader, partition"
+            echo "table and app — written at offset \`0x0\`. Note \`0x0\`, not the \`0x1000\` used"
+            echo "by the older Xtensa chips; the ESP32-C6 places its bootloader at zero."
+            echo ""
+            echo "### Web flasher (no install)"
+            echo ""
+            echo "1. Open <https://espressif.github.io/esp-launchpad/> in Chrome or Edge."
+            echo "   It needs WebSerial, so Firefox and Safari will not work."
+            echo "2. Open the **DIY** tab."
+            echo "3. Connect the board over USB, click **Connect**, and pick its serial port."
+            echo "4. Select \`firmware-${VERSION}-full.bin\` and set the flash address to \`0x0\`."
+            echo "5. Click **Program**. The board reboots into the new firmware when it finishes."
+            echo ""
+            echo "Erasing the whole flash first is unnecessary — this image already replaces"
+            echo "the bootloader, partition table and app. Settings are not at risk either way:"
+            echo "they live on the SD card in \`/config.ini\`, not in flash."
+            echo ""
+            echo "### esptool"
+            echo ""
+            echo "\`\`\`"
+            echo "esptool --chip esp32c6 write-flash 0x0 firmware-${VERSION}-full.bin"
+            echo "\`\`\`"
+            echo ""
+            echo "### firmware-${VERSION}-app.bin"
+            echo ""
+            echo "The application partition alone, for OTA or for reflashing over an existing"
+            echo "install at \`0x10000\`. **Use esptool for this, not the web flasher** — it writes"
+            echo "exactly the offset given and erases only the sectors it touches, whereas a"
+            echo "browser tool makes it easy to erase the chip or write to the wrong address,"
+            echo "either of which removes the bootloader and leaves the board unable to boot."
+            echo "Only valid on a board already running this same 8MB / 3MB-APP partition"
+            echo "scheme; otherwise flash the full image. Recover from a bad app-only flash by"
+            echo "writing \`firmware-${VERSION}-full.bin\` at \`0x0\` again."
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Build provenance"
+            echo ""
             echo "Built from \`${GITHUB_SHA}\` with the toolchain pinned in CI:"
             echo ""
             echo "- ESP32 core \`${ESP32_CORE_VERSION}\`"
@@ -150,16 +227,6 @@ jobs:
             echo "\`\`\`"
             cat flash-line.txt
             echo "\`\`\`"
-            echo ""
-            echo "### Flashing"
-            echo ""
-            echo "\`firmware-${VERSION}-full.bin\` is a complete image — bootloader, partition table and app — flashed at offset \`0x0\`:"
-            echo ""
-            echo "\`\`\`"
-            echo "esptool --chip esp32c6 write-flash 0x0 firmware-${VERSION}-full.bin"
-            echo "\`\`\`"
-            echo ""
-            echo "\`firmware-${VERSION}-app.bin\` is the application partition alone, for OTA or for reflashing over an existing install at \`0x10000\`."
           } > notes.md
 
           FLAGS=(--title "$VERSION" --notes-file notes.md)

--- a/README.md
+++ b/README.md
@@ -816,6 +816,50 @@ dates = 06-08-2017,20-08-1989,07-09-2017,21-03-1989
 
 ## Build & Flash
 
+There are two routes. Flashing a prebuilt release takes a couple of minutes and
+needs no toolchain; building from source is only necessary if you want to change
+the firmware.
+
+### Option A — Flash a prebuilt release (no toolchain)
+
+Every release ships `firmware-<version>-full.bin`, a complete image containing
+the bootloader, partition table and application.
+
+1. Download `firmware-<version>-full.bin` from
+   [Releases](https://github.com/andreimagic/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock/releases).
+2. Open **[Espressif's ESP Launchpad](https://espressif.github.io/esp-launchpad/)**
+   in **Chrome or Edge**. It flashes over WebSerial, which Firefox and Safari do
+   not support.
+3. Open the **DIY** tab, connect the board over USB, click **Connect** and pick
+   its serial port.
+4. Select the `.bin` file and set the flash address to **`0x0`**.
+5. Click **Program**. The board reboots into the new firmware when it finishes.
+
+> **The address is `0x0`, not `0x1000`.** The ESP32-C6 places its bootloader at
+> zero; `0x1000` is the offset used by the older Xtensa parts, and using it
+> produces an image that will not boot.
+
+You do not need to erase the flash first — the image already spans it. Your
+settings are safe either way: they live on the SD card in `/config.ini`, not in
+flash.
+
+If you prefer a command line, the same image works with
+[esptool](https://github.com/espressif/esptool):
+
+```bash
+esptool --chip esp32c6 write-flash 0x0 firmware-<version>-full.bin
+```
+
+> Releases also contain `firmware-<version>-app.bin`, the application partition
+> on its own, for reflashing over an existing install at `0x10000`. **Use esptool
+> for that one, not a browser flasher** — esptool writes exactly the offset given
+> and erases only the sectors it touches, whereas a browser tool makes it easy to
+> erase the chip or write to the wrong address, either of which removes the
+> bootloader and leaves the board unable to boot. Recover by flashing
+> `firmware-<version>-full.bin` at `0x0` again.
+
+### Option B — Build from source
+
 1. Clone the repository:
    ```bash
    git clone https://github.com/andreimagic/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock.git

--- a/docs/index.html
+++ b/docs/index.html
@@ -353,7 +353,25 @@ duration = 10
         </section>
 
         <section id="build">
-            <h2>⚡ Build & Flash</h2>
+            <h2>⚡ Build &amp; Flash</h2>
+            <p>Flashing a prebuilt release takes a couple of minutes and needs no toolchain. Building from source is only necessary if you want to change the firmware.</p>
+
+            <h3>Option A — Flash a prebuilt release (no toolchain)</h3>
+            <p>Every release ships <code class="code-inline">firmware-&lt;version&gt;-full.bin</code>, a complete image containing the bootloader, partition table and application.</p>
+            <ol>
+                <li>Download <code class="code-inline">firmware-&lt;version&gt;-full.bin</code> from <a href="https://github.com/andreimagic/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock/releases" target="_blank">Releases</a>.</li>
+                <li>Open <a href="https://espressif.github.io/esp-launchpad/" target="_blank">Espressif's ESP Launchpad</a> in <strong>Chrome or Edge</strong> — it flashes over WebSerial, which Firefox and Safari do not support.</li>
+                <li>Open the <strong>DIY</strong> tab, connect the board over USB, click <strong>Connect</strong> and pick its serial port.</li>
+                <li>Select the <code class="code-inline">.bin</code> file and set the flash address to <strong><code class="code-inline">0x0</code></strong>.</li>
+                <li>Click <strong>Program</strong>. The board reboots into the new firmware when it finishes.</li>
+            </ol>
+            <p><strong>The address is <code class="code-inline">0x0</code>, not <code class="code-inline">0x1000</code>.</strong> The ESP32-C6 places its bootloader at zero; <code class="code-inline">0x1000</code> is the offset used by the older Xtensa parts, and using it produces an image that will not boot.</p>
+            <p>You do not need to erase the flash first — the image already spans it. Your settings are safe either way: they live on the SD card in <code class="code-inline">/config.ini</code>, not in flash.</p>
+            <p>If you prefer a command line, the same image works with <a href="https://github.com/espressif/esptool" target="_blank">esptool</a>:</p>
+            <pre><code>esptool --chip esp32c6 write-flash 0x0 firmware-&lt;version&gt;-full.bin</code></pre>
+            <p>Releases also contain <code class="code-inline">firmware-&lt;version&gt;-app.bin</code>, the application partition on its own, for reflashing over an existing install at <code class="code-inline">0x10000</code>. <strong>Use esptool for that one, not a browser flasher</strong> — esptool writes exactly the offset given and erases only the sectors it touches, whereas a browser tool makes it easy to erase the chip or write to the wrong address, either of which removes the bootloader and leaves the board unable to boot. Recover by flashing <code class="code-inline">firmware-&lt;version&gt;-full.bin</code> at <code class="code-inline">0x0</code> again.</p>
+
+            <h3>Option B — Build from source</h3>
             <ol>
                 <li>Install <strong>ESP32 board support</strong> in Arduino IDE.</li>
                 <li>Select <strong>ESP32C6 Dev Module</strong>.</li>
@@ -361,7 +379,7 @@ duration = 10
                 <li>Set <strong>Flash Size</strong> to <code>8MB (64Mb)</code> and <strong>Partition Scheme</strong> to <code>8MB with spiffs (3MB APP/1.5MB SPIFFS)</code>.</li>
                 <li>Upload at `921600` baud rate and open Serial Monitor at `115200`.</li>
             </ol>
-            
+
             <h3>Troubleshooting</h3>
             <div class="table-responsive">
                 <table>


### PR DESCRIPTION
Releases have shipped a complete flashable image for a while, but nothing said
how to use it. The README and the project site both assumed the only way onto
the device was Arduino IDE — install the core, install three libraries, set six
board options, compile. That is the path for *changing* the firmware, not for
*running* it. Anyone who just wanted the clock had no documented route at all.

## release.yml

Adds a flashing section to the generated notes: the full image at `0x0`, ESP
Launchpad steps for people without a toolchain, the esptool equivalent, and what
`app.bin` is actually for.

Adds `--generate-notes`, so GitHub appends its own "What's Changed" — every PR
merged since the previous tag, with contributors and a compare link. Notes now
read Flashing → Build provenance → What's Changed.

The build provenance block is unchanged and kept last, as before.

## README and docs/index.html

`Build & Flash` splits into **Option A — flash a prebuilt release** and
**Option B — build from source**. Option B is the existing Arduino IDE
instructions, unchanged. Both files carry the same three warnings the release
notes give, since these pages are what people read first:

- The address is `0x0`, not the `0x1000` used by the older Xtensa parts. Getting
  it wrong produces an image that will not boot.
- No pre-erase is needed, and settings survive either way — they live on the SD
  card in `/config.ini`, not in flash.
- `app.bin` must go through esptool, not a browser flasher.

That last one is written from experience: flashing `app.bin` through a browser
flasher immediately after the full image cost a boot during testing. The payload
was never the problem — `merge-bin` puts that identical app at `0x10000` inside
the full image, so writing it again is a no-op. The browser tool erased or
misaddressed around it, which removed the bootloader. The docs now say so, and
say how to recover.

## Note on the commit history

The first commit hand-rolled a step that read the merge commit's PR and pasted
its title and body into the notes. The second removes it in favour of
`--generate-notes`, which is one flag and does a strictly better job: reading
only the merge commit's own PR misses everything when a release spans several
PRs and `main` is updated from a thin `development` → `main` pull request. That
also dropped the `pull-requests: read` permission the custom step had needed;
the generate-notes endpoint documents `contents: write` as sufficient, which the
workflow already had.

Worth squashing on merge — the net diff is the useful artefact.

## Verification

- YAML parses; all `run` blocks pass `bash -n`
- Release notes rendered end-to-end against a real PR body and the real flash
  line, with the workflow expressions substituted
- `docs/index.html` parses with no unclosed or mismatched tags, and the rendered
  page was checked: correct headings, all three links resolving, `<version>`
  escaping correctly in the code block

## Expected CI

Build passes. **Version check skips** — no `.ino`, `.c`, `.cpp` or `.h` touched,
so the guard's non-firmware exemption applies and no `FW_VERSION` bump is
required.

The new notes format is not visible until a release that actually bumps the
version. `v2.7.2` is already tagged, so the subsequent push to `main` will
no-op as usual.