### PR TITLE
Add CI status badges and Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Keeps the GitHub Actions we depend on current.
+#
+# Scope note: Dependabot only tracks `uses:` refs. The ESP32 core, LVGL, GFX and
+# FastIMU versions are plain env and matrix values in the workflows, so they are
+# invisible here — upstream-check.yml covers those instead. The two are
+# complementary and do not overlap.
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    # "/" scans .github/workflows only. The composite action has to be listed
+    # separately, and it is not optional: arduino/setup-arduino-cli and
+    # actions/cache are pinned *only* there, so a root-only config would never
+    # see two of the four actions this repo uses.
+    directories:
+      - "/"
+      - "/.github/actions/arduino-build"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Dependabot targets the default branch unless told otherwise. That would
+    # open bot PRs straight against main, whose ruleset allows merge commits
+    # only, skipping development entirely. These belong in the normal flow.
+    #
+    # They pass the version guard without intervention: a workflow-only diff
+    # touches no firmware sources, so version-check.yml takes its exemption
+    # path rather than demanding a FW_VERSION bump.
+    target-branch: "development"
+    # Five actions across five files. Ungrouped, a busy week is five PRs and
+    # five full compile runs; grouped, it is one.
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 # ESP32-C6 Touch LCD 1.47" — LVGL Animated Clock
 
 [![GitHub](https://img.shields.io/badge/github-andreimagic%2FESP32__C6__Touch__LCD__1__47__LVGL__Animated__Clock-blue?logo=github)](https://github.com/andreimagic/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock)
+[![Build](https://github.com/andreimagic/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/andreimagic/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock/actions/workflows/build.yml)
+[![Release](https://img.shields.io/github/v/release/andreimagic/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock)](https://github.com/andreimagic/ESP32_C6_Touch_LCD_1_47_LVGL_Animated_Clock/releases/latest)
 
 A smart animated clock for kids built on the **Waveshare ESP32-C6 Touch LCD 1.47"** board, driven by **LVGL v9**. Displays the time in a large custom font, plays animated GIF emotions on a schedule, sounds configurable buzzer alarms, runs a countdown timer, manages brightness via device tilt, hosts a full apps menu with ASCII mini-games, and supports deep-sleep power-off — all configured from a plain `config.ini` on the SD card, no recompile needed.
 


### PR DESCRIPTION
Two badges beside the existing one — build state for `main`, and the current
release version — plus Dependabot for the four actions this repo uses.

## Badges

`?branch=main` on the build badge is deliberate: without it the badge reports
the newest run on *any* branch, so an in-progress feature branch would paint the
README red. `release.yml` is deliberately not badged — it succeeds as a no-op on
most pushes to `main`, so green would carry no information.

Both verified live before committing: "Build – passing" and "release: v2.7.2".

## Dependabot

Three details here are specific to this repo rather than boilerplate.

**The composite action is listed as its own directory.** A root entry scans
`.github/workflows` only, and `arduino/setup-arduino-cli` and `actions/cache`
are pinned exclusively inside `.github/actions/arduino-build` — half the actions
in the repo would never have been seen. Confirmed by enumerating every `uses:`
ref and where it lives.

**`target-branch: development`.** Dependabot otherwise opens against the default
branch, putting bot PRs straight onto `main`, whose ruleset allows merge commits
only, skipping the `development` tier. They pass the version guard unattended,
since a workflow-only diff takes its non-firmware exemption path.

**Updates are grouped into one PR.** Five actions across five files would
otherwise mean five PRs and five full compile runs in a week where several
happen to release.

## Scope

Dependabot only tracks `uses:` refs, so the ESP32 core, LVGL, GFX and FastIMU
pins stay outside its view. `upstream-check.yml` already covers those; the two
are complementary and do not overlap.

Documentation and CI only — no firmware change, so the version guard exempts
this and no `FW_VERSION` bump is needed.